### PR TITLE
Allow newer versions of `aws-cdk-lib` peer dependency

### DIFF
--- a/packages/lambda-time-trigger/package-lock.json
+++ b/packages/lambda-time-trigger/package-lock.json
@@ -21,7 +21,7 @@
         "jsii-pacmak": "1.52.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.8.0",
+        "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },

--- a/packages/lambda-time-trigger/package.json
+++ b/packages/lambda-time-trigger/package.json
@@ -53,7 +53,7 @@
     "constructs": "10.0.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.8.0",
+    "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
We are using a version of `aws-cdk-lib` greater than the hard dependency on `2.8.0`, which errors out when installing this package.

This PR makes sure that any v2 version of `aws-cdk-lib` is allowed as a peer dependency.